### PR TITLE
Update clang-format 13.0.1

### DIFF
--- a/Formula/clang-format@13.rb
+++ b/Formula/clang-format@13.rb
@@ -2,19 +2,10 @@ class ClangFormatAT13 < Formula
   desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
   homepage "https://clang.llvm.org/docs/ClangFormat.html"
   # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/llvm-13.0.1.src.tar.xz"
+  sha256 "ec6b80d82c384acad2dc192903a6cf2cdbaffb889b84bfb98da9d71e630fc834"
   license "Apache-2.0"
   version_scheme 1
-  head "https://github.com/llvm/llvm-project.git", branch: "main"
-
-  stable do
-    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/llvm-13.0.1.src.tar.xz"
-    sha256 "ec6b80d82c384acad2dc192903a6cf2cdbaffb889b84bfb98da9d71e630fc834"
-
-    resource "clang" do
-      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang-13.0.1.src.tar.xz"
-      sha256 "787a9e2d99f5c8720aa1773e4be009461cd30d3bd40fdd24591e473467c917c9"
-    end
-  end
 
   livecheck do
     url :stable
@@ -33,32 +24,29 @@ class ClangFormatAT13 < Formula
 
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
-  uses_from_macos "python", since: :catalina
   uses_from_macos "zlib"
 
   on_linux do
     keg_only "it conflicts with llvm"
   end
 
+  resource "clang" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang-13.0.1.src.tar.xz"
+    sha256 "787a9e2d99f5c8720aa1773e4be009461cd30d3bd40fdd24591e473467c917c9"
+  end
+
   def install
-    if build.head?
-      ln_s buildpath/"clang", buildpath/"llvm/tools/clang"
-    else
-      (buildpath/"tools/clang").install resource("clang")
-    end
+    (buildpath/"tools/clang").install resource("clang")
 
-    llvmpath = build.head? ? buildpath/"llvm" : buildpath
+    system "cmake", "-G", "Ninja", "-S", buildpath, "-B", "build",
+                    "-DLLVM_EXTERNAL_PROJECTS=clang",
+                    "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+                    "-DLLVM_INCLUDE_TESTS=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build", "--target", "clang-format"
 
-    mkdir llvmpath/"build" do
-      args = std_cmake_args
-      args << "-DLLVM_EXTERNAL_PROJECTS=\"clang\""
-      args << ".."
-      system "cmake", "-G", "Ninja", *args
-      system "ninja", "clang-format"
-    end
-
-    bin.install llvmpath/"build/bin/clang-format" => "clang-format-13"
-    bin.install llvmpath/"tools/clang/tools/clang-format/git-clang-format" => "git-clang-format-13"
+    bin.install buildpath/"build/bin/clang-format" => "clang-format-13"
+    bin.install buildpath/"tools/clang/tools/clang-format/git-clang-format" => "git-clang-format-13"
   end
 
   test do


### PR DESCRIPTION
### Description
Cleans up build command block to invoke `ninja` via `cmake` and also remove `HEAD` because formula is pinned at a specific release.

### Motivation and Context
Clean up Formula and remove a set of dependencies (mainly Python) improving installation speed on CI runners.

### How Has This Been Tested?
Build tested locally.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
