### PR TITLE
clang-format@17 17.0.3

### DIFF
--- a/Formula/clang-format@17.rb
+++ b/Formula/clang-format@17.rb
@@ -1,0 +1,89 @@
+class ClangFormatAT17 < Formula
+  desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
+  homepage "https://clang.llvm.org/docs/ClangFormat.html"
+  # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/llvm-17.0.3.src.tar.xz"
+  sha256 "18fa6b5f172ddf5af9b3aedfdb58ba070fd07fc45e7e589c46c350b3cc066bc1"
+  license "Apache-2.0"
+  version_scheme 1
+  head "https://github.com/llvm/llvm-project.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/llvmorg[._-]v?(\d+(?:\.\d+)+)/i)
+    strategy :github_latest
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+  uses_from_macos "python", since: :catalina
+  uses_from_macos "zlib"
+
+  on_linux do
+    keg_only "it conflicts with llvm"
+  end
+
+  resource "clang" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/clang-17.0.3.src.tar.xz"
+    sha256 "605a6a091e9d14721ba00048b7409fb73119a60756c959a19a177c8e057d947c"
+  end
+
+  resource "cmake" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/cmake-17.0.3.src.tar.xz"
+    sha256 "54fc534f0da09088adbaa6c3bfc9899a500153b96e60c2fb9322a7aa37b1027a"
+  end
+
+  resource "third-party" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/third-party-17.0.3.src.tar.xz"
+    sha256 "6e84ff16044d698ff0f24e7445f9f47818e6523913a006a5e1ea79625b429b7b"
+  end
+
+  def install
+    llvmpath = if build.head?
+      ln_s buildpath/"clang", buildpath/"llvm/tools/clang"
+
+      buildpath/"llvm"
+    else
+      (buildpath/"src").install buildpath.children
+      (buildpath/"src/tools/clang").install resource("clang")
+      (buildpath/"cmake").install resource("cmake")
+      (buildpath/"third-party").install resource("third-party")
+
+      buildpath/"src"
+    end
+
+    system "cmake", "-G", "Ninja", "-S", llvmpath, "-B", "build",
+                    "-DLLVM_EXTERNAL_PROJECTS=clang",
+                    "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+                    "-DLLVM_INCLUDE_TESTS=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build", "--target", "clang-format"
+
+    git_clang_format = llvmpath/"tools/clang/tools/clang-format/git-clang-format"
+    inreplace git_clang_format, /clang-format/, "clang-format-17"
+
+    bin.install "build/bin/clang-format" => "clang-format-17"
+    bin.install git_clang_format => "git-clang-format-17"
+    (share/"clang").install llvmpath.glob("tools/clang/tools/clang-format/clang-format*")
+  end
+
+  test do
+    system "git", "init"
+    system "git", "commit", "--allow-empty", "-m", "initial commit", "--quiet"
+
+    # NB: below C code is messily formatted on purpose.
+    (testpath/"test.c").write <<~EOS
+      int         main(char *args) { \n   \t printf("hello"); }
+    EOS
+    system "git", "add", "test.c"
+
+    assert_equal "int main(char *args) { printf(\"hello\"); }\n",
+        shell_output("#{bin}/clang-format-17 -style=Google test.c")
+
+    ENV.prepend_path "PATH", bin
+    assert_match "test.c", shell_output("git clang-format-17", 1)
+  end
+end


### PR DESCRIPTION
### Description
Adds a pinned formula for clang-format 17.0.3.

### Motivation and Context
Homebrew's clang-format is already on version 17.0.6, but Microsoft has only added version 17.0.3. If there are meaningful changes in formatting between patch levels, a Homebrew formula for the older version needs to be available to avoid mismatched formatting checks on CI.

### How Has This Been Tested?
Will be tested by `brew-bot`. Style was checked locally.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
