### PR TITLE
clang-format@17: revision bump (macos-14 bottle)

### DIFF
--- a/Formula/clang-format@17.rb
+++ b/Formula/clang-format@17.rb
@@ -5,6 +5,7 @@ class ClangFormatAT17 < Formula
   url "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/llvm-17.0.3.src.tar.xz"
   sha256 "18fa6b5f172ddf5af9b3aedfdb58ba070fd07fc45e7e589c46c350b3cc066bc1"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
   head "https://github.com/llvm/llvm-project.git", branch: "main"
 


### PR DESCRIPTION
### Description
Bumps revision of clang-format@17 formula to add macOS 14-based bottle.

### Motivation and Context
Creating a macOS 14-based bottle enables use of clang-format@17 on GitHub Actions runners with the same OS without a costly full compilation of `clang-format` on every run.

### How Has This Been Tested?
Will be automatically tested by Homebrew test bot.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
