### PR TITLE
Add clang-format 18.1.8

### DIFF
--- a/Formula/clang-format@18.rb
+++ b/Formula/clang-format@18.rb
@@ -1,0 +1,93 @@
+class ClangFormatAT18 < Formula
+  desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
+  homepage "https://clang.llvm.org/docs/ClangFormat.html"
+  # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-18.1.8.src.tar.xz"
+  sha256 "f68cf90f369bc7d0158ba70d860b0cb34dbc163d6ff0ebc6cfa5e515b9b2e28d"
+  license "Apache-2.0"
+  version_scheme 1
+  head "https://github.com/llvm/llvm-project.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/llvmorg[._-]v?(\d+(?:\.\d+)+)/i)
+    strategy :github_latest
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+  uses_from_macos "python", since: :catalina
+  uses_from_macos "zlib"
+
+  on_linux do
+    keg_only "it conflicts with llvm"
+  end
+
+  resource "clang" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang-18.1.8.src.tar.xz"
+    sha256 "5724fe0a13087d5579104cedd2f8b3bc10a212fb79a0fcdac98f4880e19f4519"
+  end
+
+  resource "cmake" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/cmake-18.1.8.src.tar.xz"
+    sha256 "59badef592dd34893cd319d42b323aaa990b452d05c7180ff20f23ab1b41e837"
+  end
+
+  resource "third-party" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/third-party-18.1.8.src.tar.xz"
+    sha256 "b76b810f3d3dc5d08e83c4236cb6e395aa9bd5e3ea861e8c319b216d093db074"
+  end
+
+  def install
+    odie "clang resource needs to be updated" if build.stable? && version != resource("clang").version
+    odie "cmake resource needs to be updated" if build.stable? && version != resource("cmake").version
+    odie "third-party resource needs to be updated" if build.stable? && version != resource("third-party").version
+
+    llvmpath = if build.head?
+      ln_s buildpath/"clang", buildpath/"llvm/tools/clang"
+
+      buildpath/"llvm"
+    else
+      (buildpath/"src").install buildpath.children
+      (buildpath/"src/tools/clang").install resource("clang")
+      (buildpath/"cmake").install resource("cmake")
+      (buildpath/"third-party").install resource("third-party")
+
+      buildpath/"src"
+    end
+
+    system "cmake", "-G", "Ninja", "-S", llvmpath, "-B", "build",
+                    "-DLLVM_EXTERNAL_PROJECTS=clang",
+                    "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+                    "-DLLVM_INCLUDE_TESTS=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build", "--target", "clang-format"
+
+    git_clang_format = llvmpath/"tools/clang/tools/clang-format/git-clang-format"
+    inreplace git_clang_format, /clang-format/, "clang-format-18"
+
+    bin.install "build/bin/clang-format" => "clang-format-18"
+    bin.install git_clang_format => "git-clang-format-18"
+    (share/"clang").install llvmpath.glob("tools/clang/tools/clang-format/clang-format*")
+  end
+
+  test do
+    system "git", "init"
+    system "git", "commit", "--allow-empty", "-m", "initial commit", "--quiet"
+
+    # NB: below C code is messily formatted on purpose.
+    (testpath/"test.c").write <<~EOS
+      int         main(char *args) { \n   \t printf("hello"); }
+    EOS
+    system "git", "add", "test.c"
+
+    assert_equal "int main(char *args) { printf(\"hello\"); }\n",
+        shell_output("#{bin}/clang-format-18 -style=Google test.c")
+
+    ENV.prepend_path "PATH", bin
+    assert_match "test.c", shell_output("git clang-format-18", 1)
+  end
+end


### PR DESCRIPTION
### Description
Adds custom formula for clang-format 18.1.8.

### Motivation and Context
Allows Linux and macOS to use the same clang-format version as shipped by recent Visual Studio versions.

### How Has This Been Tested?
Formula will be tested by CI workflow.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
