### PR TITLE
CI: Fix target branch for push action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{ github.token }}
-          branch: master
+          branch: main
 
       - name: Delete branch
         if: github.event.pull_request.head.repo.fork == false


### PR DESCRIPTION
### Description
Fixes GitHub Actions workflow for publishing new formulas.

### Motivation and Context
The repository uses the `main` variant instead of the more common `master` variant.

### How Has This Been Tested?
Will need to be tested by doing a publish run on an open formula update.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
