### PR TITLE
clang-format@17: Remove installation of shared tools

### DIFF
--- a/Formula/clang-format@17.rb
+++ b/Formula/clang-format@17.rb
@@ -5,7 +5,7 @@ class ClangFormatAT17 < Formula
   url "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/llvm-17.0.3.src.tar.xz"
   sha256 "18fa6b5f172ddf5af9b3aedfdb58ba070fd07fc45e7e589c46c350b3cc066bc1"
   license "Apache-2.0"
-  revision 1
+  revision 2
   version_scheme 1
   head "https://github.com/llvm/llvm-project.git", branch: "main"
 
@@ -75,7 +75,6 @@ class ClangFormatAT17 < Formula
 
     bin.install "build/bin/clang-format" => "clang-format-17"
     bin.install git_clang_format => "git-clang-format-17"
-    (share/"clang").install llvmpath.glob("tools/clang/tools/clang-format/clang-format*")
   end
 
   test do


### PR DESCRIPTION
### Description
Remove step to install additional helper scripts from the `share` subdirectory.

### Motivation and Context
These tools would clobber the same symlinks created when installing any other pinned custom variant of clang-format.

### How Has This Been Tested?
Installed `clang-format@17` successfully with `clang-format@19` installed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
