### PR TITLE
clang-format@18: Remove installation of shared tools

### DIFF
--- a/Formula/clang-format@18.rb
+++ b/Formula/clang-format@18.rb
@@ -5,6 +5,7 @@ class ClangFormatAT18 < Formula
   url "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-18.1.8.src.tar.xz"
   sha256 "f68cf90f369bc7d0158ba70d860b0cb34dbc163d6ff0ebc6cfa5e515b9b2e28d"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
   head "https://github.com/llvm/llvm-project.git", branch: "main"
 
@@ -78,7 +79,6 @@ class ClangFormatAT18 < Formula
 
     bin.install "build/bin/clang-format" => "clang-format-18"
     bin.install git_clang_format => "git-clang-format-18"
-    (share/"clang").install llvmpath.glob("tools/clang/tools/clang-format/clang-format*")
   end
 
   test do


### PR DESCRIPTION
### Description
Remove step to install additional helper scripts from the `share` subdirectory.

### Motivation and Context
These tools would clobber the same symlinks created when installing any other pinned custom variant of clang-format.

### How Has This Been Tested?
Installed `clang-format@18` successfully with `clang-format@19` installed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
