### PR TITLE
clang-format@19: Remove installation of shared tools

### DIFF
--- a/Formula/clang-format@19.rb
+++ b/Formula/clang-format@19.rb
@@ -5,6 +5,7 @@ class ClangFormatAT19 < Formula
   url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.1/llvm-19.1.1.src.tar.xz"
   sha256 "15a7c77f9c39444d9dd6756b75b9a70129dcbd1e340724a6e45b3b488f55bc4b"
   license "Apache-2.0" => { with: "LLVM-exception" }
+  revision 1
   version_scheme 1
   head "https://github.com/llvm/llvm-project.git", branch: "main"
 
@@ -78,7 +79,6 @@ class ClangFormatAT19 < Formula
 
     bin.install "build/bin/clang-format" => "clang-format-19"
     bin.install git_clang_format => "git-clang-format-19"
-    (share/"clang").install llvmpath.glob("tools/clang/tools/clang-format/clang-format*")
   end
 
   test do


### PR DESCRIPTION
### Description
Remove step to install additional helper scripts from the `share` subdirectory.

### Motivation and Context
These tools would clobber the same symlinks created when installing any other pinned custom variant of clang-format.

### How Has This Been Tested?
Installed `clang-format@19` successfully with `clang-format@17` installed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
