### PR TITLE
CI: Add macos-15 runner to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_API_TOKEN }}


### PR DESCRIPTION
### Description
Adds `macos-15` to the architecture matrix of the `tests` workflow.

### Motivation and Context
Ensures that precompiled packages exist for macos-15 runners used by projects that also use this Homebrew tap for access to pinned clang-format versions.

### How Has This Been Tested?
Needs successful CI run for tests.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
