### PR TITLE
clang-format@22: Add clang-format 22.1.3

### DIFF
--- a/Formula/clang-format@22.rb
+++ b/Formula/clang-format@22.rb
@@ -1,0 +1,56 @@
+class ClangFormatAT22 < Formula
+  desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
+  homepage "https://clang.llvm.org/docs/ClangFormat.html"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.3/llvm-project-22.1.3.src.tar.xz"
+  sha256 "2488c33a959eafba1c44f253e5bbe7ac958eb53fa626298a3a5f4b87373767cd"
+  # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  license "Apache-2.0" => { with: "LLVM-exception" }
+  version_scheme 1
+  head "https://github.com/llvm/llvm-project.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/llvmorg[._-]v?(\d+(?:\.\d+)+)/i)
+    strategy :github_latest
+  end
+
+  depends_on "cmake" => :build
+
+  uses_from_macos "python"
+
+  on_linux do
+    keg_only "it conflicts with llvm"
+  end
+
+  def install
+    system "cmake", "-S", "llvm", "-B", "build",
+                    "-DLLVM_ENABLE_PROJECTS=clang",
+                    "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build", "--target", "clang-format"
+
+    git_clang_format = buildpath/"clang/tools/clang-format/git-clang-format"
+    inreplace git_clang_format, /clang-format/, "clang-format-22"
+
+    bin.install "build/bin/clang-format" => "clang-format-22"
+    bin.install git_clang_format => "git-clang-format-22"
+  end
+
+  test do
+    system "git", "init"
+    system "git", "commit", "--allow-empty", "-m", "initial commit", "--quiet"
+
+    # NB: below C code is messily formatted on purpose.
+    (testpath/"test.c").write <<~C
+      int         main(char *args) { \n   \t printf("hello"); }
+    C
+    system "git", "add", "test.c"
+
+    assert_equal <<~C, shell_output("#{bin}/clang-format-22 -style=Google test.c")
+      int main(char* args) { printf("hello"); }
+    C
+
+    ENV.prepend_path "PATH", bin
+    assert_match "test.c", shell_output("git clang-format-22", 1)
+  end
+end


### PR DESCRIPTION
### Description
Adds pinned formula for clang-format v22.1.3 for compatibility with the version shipped by Visual Studio 2026.

### Motivation and Context
Allows macOS and Linux developers to use the same clang-format version as Windows developers.

### How Has This Been Tested?
Needs testing on CI as this is a custom pinned formula.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
